### PR TITLE
Inspect cisbed runs surface mass balance.

### DIFF
--- a/figures/Makefile
+++ b/figures/Makefile
@@ -9,9 +9,9 @@
 EXT = pdf
 
 # python executable
-PY = PYTHONPATH=iceplotlib python2
+PY = python
 
-# all python figures (broken: ciscyc_lr_ts_diff ciscyc_lr_ts_scaling ciskap_plot_sdeffect)
+# old python 2 figures
 PY_FIGS = $(addprefix cisbed_, relaxtime timeseries \
             $(addprefix lr_, glacareas)) \
           $(addprefix ciscyc_, locmap \
@@ -29,6 +29,14 @@ PY_FIGS = $(addprefix cisbed_, relaxtime timeseries \
             $(addprefix map_, cordillera northamerica) \
             $(addprefix paleo_, glaciation timeseries) \
             $(addprefix plot_, atm cover erosion lastflow lgm sdmap snapshots))
+
+# broken python 3 figures
+PY_FIGS = $(addprefix cisbed_, pugetsound relaxtime)
+
+# new python 3 figures
+PY_FIGS = $(addprefix cisbed_, iodp341 massbalance timestamps timeseries) \
+          $(addprefix ciscyc_, \
+            $(addprefix hr_, deglacshots ))
 PY_FIGS := $(addsuffix .$(EXT), $(PY_FIGS))
 
 # tex executable
@@ -45,6 +53,9 @@ PYTEX_FIGS := $(addsuffix .$(EXT), $(PYTEX_FIGS))
 
 # all figures
 ALL_FIGS = $(PY_FIGS) $(PYTEX_FIGS) $(TEX_FIGS)
+
+# tex and pytex figures are broken
+ALL_FIGS = $(PY_FIGS)
 
 
 # Rules

--- a/figures/cisbed_massbalance.py
+++ b/figures/cisbed_massbalance.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# Copyright (c) 2023, Julien Seguinot (juseg.dev)
+# Creative Commons Attribution-ShareAlike 4.0 International License
+# (CC BY-SA 4.0, http://creativecommons.org/licenses/by-sa/4.0/)
+
+"""Cordillera bedrock surface mass balance."""
+
+import absplots as apl
+import hyoga.open
+import util
+
+
+def main():
+    """Main program called during execution."""
+
+    # initialize figure
+    fig, axes = apl.subplots_mm(
+        figsize=(177, 80), nrows=2, ncols=3, sharex=True, sharey=True,
+        gridspec_kw={
+            'left': 1.5, 'right': 1.5, 'bottom': 1, 'top': 1.5,
+            'hspace': 1.5, 'wspace': 1.5})
+    cax = fig.add_axes_mm([57*2+19+1.5*4, 38/3-3, 57*2/3-1.5, 3])
+
+    # for each selected age
+    for ax, age in zip(axes.flat, range(16, 10, -1)):
+
+        # open extra output
+        with hyoga.open.subdataset(
+                '~/pism/output/1.1.3/cisbed4.5km.grip.0620.ghf70/'
+                'ex.{:07.0f}.nc', time=-age*1e3, shift=120000) as ds:
+
+            # plot ice geometry
+            ds.hyoga.plot.bedrock_altitude(ax=ax, vmin=0, vmax=4500)
+            ds.hyoga.plot.ice_margin(ax=ax)
+            ds.hyoga.plot.surface_altitude_contours(ax=ax)
+
+            # plot surface runoff
+            ds.surface_runoff_flux.where(ds.thk > 1).plot.imshow(
+                ax=ax, cmap='Reds', vmin=0, vmax=6e3,
+                cbar_ax=cax, cbar_kwargs={
+                    'label': r'surface runoff ($kg\,m^{-2}\,a{-1}$)',
+                    'orientation': 'horizontal'})
+
+            # plot equilibrium line
+            (ds.surface_accumulation_flux - ds.surface_melt_flux).where(
+                ds.thk > 1).plot.contour(
+                    ax=ax, colors='0.25', levels=[0], linestyles='--')
+
+            # add coastline and rivers
+            ax = ds.hyoga.plot.natural_earth(ax=ax)
+
+        # set axes properties
+        util.pl.add_subfig_label(f'{age:.1f} ka', ax=ax)
+        ax.set_title('')
+        ax.set_xlim(-2200e3, -1300e3)
+        ax.set_ylim(300e3, 900e3)
+
+    # save
+    fig.savefig(__file__[:-3])
+
+
+if __name__ == '__main__':
+    main()

--- a/figures/cisbed_timestamps.py
+++ b/figures/cisbed_timestamps.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright (c) 2015-2021, Julien Seguinot (juseg.github.io)
+# Creative Commons Attribution-ShareAlike 4.0 International License
+# (CC BY-SA 4.0, http://creativecommons.org/licenses/by-sa/4.0/)
+
+"""Cordillera bedrock computing time stamps."""
+
+import absplots as apl
+import pismx.open
+
+
+def main():
+    """Main program called during execution."""
+
+    # initialize figure
+    fig, ax = apl.subplots_mm(figsize=(85, 80), gridspec_kw=dict(
+            left=12, right=1.5, bottom=12, top=1.5))
+
+    # select runs that are not broken
+    # FIXME cisbed4.5km.epica.590.gou11simi.num1e21 has non-increasing times
+    # FIXME cisbed4.3km.grip.0620.gou11simi.num1e21 has different pism_config?!
+    # FIXME cisbed4.3km.epica.0620.gou11simi.num1e21 has different mappings?!
+    for run in ['cisbed4.10km.grip.0620.gou11simi',
+                'cisbed4.10km.epica.0590.gou11simi',
+                'cisbed4.5km.grip.0620.gou11simi',
+                'cisbed4.5km.epica.0590.gou11simi',
+                'cisbed4.3km.grip.0620.gou11simi.num1e21',
+                'cisbed4.3km.epica.0590.gou11simi.num1e21']:
+
+        # open extra output
+        print(run)
+        with pismx.open.mfdataset(
+                '~/pism/output/1.1.3/{}/ex.*.nc'.format(run),
+                coords='minimal', compat='override') as ds:
+            diff = ds.timestamp.diff('age')
+            procs = ds['rank'].max() + 1
+            stamp = diff.where(diff > 0, ds.timestamp[1:]).cumsum()
+            stamp.plot(
+                ax=ax, color='C0' if 'grip' in run else 'C2',
+                label=r'{}, {}, {:d} cores, {:.0f} kch'.format(
+                    run.split('.')[1], run.split('.')[2].upper(), int(procs),
+                    float(procs*stamp[-1]/1e3)))
+
+    # set axes properies
+    ax.invert_xaxis()
+    ax.set_xlabel('model age (ka)')
+    ax.set_ylabel('computing time (hours)')
+    ax.legend(loc='best')
+
+    # save
+    fig.savefig(__file__[:-3])
+
+
+if __name__ == '__main__':
+    main()

--- a/figures/cisbed_timestamps.py
+++ b/figures/cisbed_timestamps.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
-# Copyright (c) 2015-2021, Julien Seguinot (juseg.github.io)
+#!/usr/bin/python
+# Copyright (c) 2015-2023, Julien Seguinot (juseg.dev)
 # Creative Commons Attribution-ShareAlike 4.0 International License
 # (CC BY-SA 4.0, http://creativecommons.org/licenses/by-sa/4.0/)
 
 """Cordillera bedrock computing time stamps."""
 
 import absplots as apl
-import pismx.open
+import hyoga.open
 
 
 def main():
@@ -28,8 +28,7 @@ def main():
                 'cisbed4.3km.epica.0590.gou11simi.num1e21']:
 
         # open extra output
-        print(run)
-        with pismx.open.mfdataset(
+        with hyoga.open.mfdataset(
                 '~/pism/output/1.1.3/{}/ex.*.nc'.format(run),
                 coords='minimal', compat='override') as ds:
             diff = ds.timestamp.diff('age')


### PR DESCRIPTION
Surface fluxes were unfortunately not saved in 2016 _cycle_ runs. Inspect newer _bedrock_ runs for "cumulative" fluxes made available in PISM since.
- [x] Find broken runs with timeseries plot.
- [x] Add old timestamps figure from Anafi.
- [x] Add surface melt and equilibrium line plot.